### PR TITLE
Fix nolt-build-gir.sh

### DIFF
--- a/nolt-02-build-gir.sh
+++ b/nolt-02-build-gir.sh
@@ -11,6 +11,7 @@ scanner_flags="$scanner_flags --library=sample"
 scanner_flags="$scanner_flags --include=GObject-2.0"
 scanner_flags="$scanner_flags --pkg-export=sample"
 scanner_flags="$scanner_flags --output Sample-1.0.gir"
+scanner_flags="$scanner_flags --library-path=."
 
 set -x
 g-ir-scanner $scanner_flags greeter.c greeter.h


### PR DESCRIPTION
Hi, I saw your post on the gtk osx mailinglist about this issue recently and have been experiencing the same problem with meson, which also uses the --no-libtool option. I manage to generate the gobject-introspection bindings correctly when applying the small change to your g-ir-scanner invocation, as well as with the following patch to the gobject-introspection source code:

````diff
diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
index 29de0ee..8d89502 100644
--- a/giscanner/ccompiler.py
+++ b/giscanner/ccompiler.py
@@ -119,7 +119,7 @@ class CCompiler(object):
         if self.check_is_msvc():
             runtime_path_envvar = ['LIB', 'PATH']
         else:
-            runtime_path_envvar = ['LD_LIBRARY_PATH']
+            runtime_path_envvar = ['LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH']
             # Search the current directory first
             # (This flag is not supported nor needed for Visual C++)
             args.append('-L.')

````


I would be grateful if you could confirm this works at your end as well: if so, I will open a pull request on the GNOME gitlab for this.